### PR TITLE
sign up, login 중복 되는 것 삭제

### DIFF
--- a/hifive/templates/shared/navbar.html
+++ b/hifive/templates/shared/navbar.html
@@ -69,37 +69,6 @@
             </li>
             <!-- End Users -->
 
-            <!-- Authentication -->
-            <li class="side-nav-menu-item side-nav-has-menu">
-                <a class="side-nav-menu-link media align-items-center" href="#"
-                   data-target="#subPages">
-              <span class="side-nav-menu-icon d-flex mr-3">
-                <i class="gd-lock"></i>
-              </span>
-                    <span class="side-nav-fadeout-on-closed media-body">Authentication</span>
-                    <span class="side-nav-control-icon d-flex">
-                <i class="gd-angle-right side-nav-fadeout-on-closed"></i>
-              </span>
-                    <span class="side-nav__indicator side-nav-fadeout-on-closed"></span>
-                </a>
-
-                <!-- Pages: subPages -->
-                <ul id="subPages" class="side-nav-menu side-nav-menu-second-level mb-0">
-
-                    <li class="side-nav-menu-item">
-                        <a class="side-nav-menu-link" href="#">Forgot Password</a>
-                    </li>
-                    <li class="side-nav-menu-item">
-                        <a class="side-nav-menu-link" href="#">Forgot Password 2</a>
-                    </li>
-                    <li class="side-nav-menu-item">
-                        <a class="side-nav-menu-link" href="#">Email Verification</a>
-                    </li>
-                </ul>
-                <!-- End Pages: subPages -->
-            </li>
-            <!-- End Authentication -->
-
             <!-- Settings -->
             <li class="side-nav-menu-item">
                 <a class="side-nav-menu-link media align-items-center" href="#">


### PR DESCRIPTION
navbar에 Users와 Authentication 부분에 둘다 sign up 과 login 항목이 있어서 User 에만 남겨두고 Authentication 에서는 삭제
![image](https://user-images.githubusercontent.com/82003899/130955037-07894c42-cd1e-4666-8c11-36cd70dec2ff.png)
